### PR TITLE
Add balanceUpdate to UnicornFy

### DIFF
--- a/unicorn_fy/unicorn_fy.py
+++ b/unicorn_fy/unicorn_fy.py
@@ -218,6 +218,8 @@ class UnicornFy(object):
                 stream_data = {'data': stream_data}
             elif stream_data['e'] == 'listStatus':
                 stream_data = {'data': stream_data}
+            elif stream_data['e'] == 'balanceUpdate':
+                stream_data = {'data': stream_data}
         except KeyError:
             pass
         try:
@@ -489,6 +491,13 @@ class UnicornFy(object):
                             'free': item['f'],
                             'locked': item['l']}
                 unicorn_fied_data['balances'] += [new_item]
+        elif stream_data['data']['e'] == 'balanceUpdate':
+            unicorn_fied_data = {'stream_type': '!userData@arr',
+                                 'event_type': stream_data['data']['e'],
+                                 'event_time': stream_data['data']['E'],
+                                 'asset': stream_data['data']['a'],
+                                 'balance_delta': stream_data['data']['d'],
+                                 'clear_time': stream_data['data']['T']}
         elif stream_data['data']['e'] == 'executionReport':
             unicorn_fied_data = {'stream_type': '!userData@arr',
                                  'event_type': stream_data['data']['e'],
@@ -559,6 +568,8 @@ class UnicornFy(object):
             if stream_data['e'] == 'outboundAccountInfo':
                 stream_data = {'data': stream_data}
             elif stream_data['e'] == 'executionReport':
+                stream_data = {'data': stream_data}
+            elif stream_data['e'] == 'balanceUpdate':
                 stream_data = {'data': stream_data}
         except KeyError:
             pass
@@ -798,6 +809,13 @@ class UnicornFy(object):
                                 'free': item['f'],
                                 'locked': item['l']}
                     unicorn_fied_data['balances'] += [new_item]
+            elif stream_data['data']['e'] == 'balanceUpdate':
+                unicorn_fied_data = {'stream_type': '!userData@arr',
+                                 'event_type': stream_data['data']['e'],
+                                 'event_time': stream_data['data']['E'],
+                                 'asset': stream_data['data']['a'],
+                                 'balance_delta': stream_data['data']['d'],
+                                 'clear_time': stream_data['data']['T']}
             elif stream_data['data']['e'] == 'executionReport':
                 unicorn_fied_data = {'stream_type': '!userData@arr',
                                      'event_type': stream_data['data']['e'],

--- a/unittest_unicorn_fy.py
+++ b/unittest_unicorn_fy.py
@@ -150,6 +150,11 @@ class TestBinanceComWebsocket(unittest.TestCase):
         asserted_result = "{'stream_type': 'ethusdt@listStatus', 'event_type': 'listStatus', 'event_time': 1606946194410, 'symbol': 'ETHUSDT', 'order_list_id': 10717037, 'contingency_type': 'OCO', 'list_status_type': 'ALL_DONE', 'list_order_status': 'ALL_DONE', 'list_reject_reason': 'NONE', 'list_client_order_id': 'i8B7NXuB37QkJ2Vy8f5KHh', 'transaction_time': 1606946194409, 'objects': [{'symbol': 'ETHUSDT', 'order_id': 2175939815, 'client_order_id': 'electron_648187c31bda49b6a2e81d23ae0'}, {'symbol': 'ETHUSDT', 'order_id': 2175939816, 'client_order_id': '84wruoWCZdkBUqbqlKfpv6'}], 'unicorn_fied': ['binance.com', '" + self.unicorn_fy_version + "']}"
         self.assertEqual(str(self.unicorn_fy.binance_com_websocket(data)), asserted_result)
 
+    def test_balanceUpdate(self):
+        data = '{"e":"balanceUpdate","E":1615926131286,"a":"USDT","d":"1.00000000","T":1615926131285}'
+        asserted_result = "{'stream_type': '!userData@arr', 'event_type': 'balanceUpdate', 'event_time': 1615926131286, 'asset': 'USDT', 'balance_delta': '1.00000000', 'clear_time': 1615926131285, 'unicorn_fied': ['binance.com', '" + self.unicorn_fy_version + "']}"
+        self.assertEqual(str(self.unicorn_fy.binance_com_websocket(data)), asserted_result)
+
     def test_template(self):
         data = ''
         asserted_result = "" + self.unicorn_fy_version + "']}"


### PR DESCRIPTION
# PR Details

Adding balanceUpdate key to UnicornFy. When a transfer from spot to cross/isolated margin (and vice-versa) happens, Binance sends a json with event type as 'balanceUpdate'. This event type was not mapped in UnicornFy.

Here shows exactly what to expect from the payload: https://github.com/binance/binance-spot-api-docs/blob/master/user-data-stream.md#balance-update

```
{
  "e": "balanceUpdate",         //Event Type
  "E": 1573200697110,           //Event Time
  "a": "BTC",                   //Asset
  "d": "100.00000000",          //Balance Delta
  "T": 1573200697068            //Clear Time
}
```` 

## Description

<!--- Describe your changes in detail -->

## Related Issue

https://github.com/oliver-zehentleitner/unicorn-fy/issues/20

## Motivation and Context

When create_stream is using output=UnicornFy an error stops the websocket whenever a transfer occurs between accounts.

```
unicorn_stream                | 2021-03-16 20:21:58,309 - DEBUG |client - received solicited pong: 60806399
unicorn_stream                | 2021-03-16 20:22:10,470 - DEBUG |client - event = data_received(<72 bytes>)
unicorn_stream                | 2021-03-16 20:22:10,470 - DEBUG |client - event = data_received(<97 bytes>)
unicorn_stream                | 2021-03-16 20:22:10,481 - DEBUG |client < Frame(fin=True, opcode=1, data=b'{"e":"balanceUpdate","E":1615926131286,"a":"USDT","d":"1.00000000","T":1615926131285}', rsv1=False, rsv2=False, rsv3=False)
unicorn_stream                | 2021-03-16 20:22:10,491 - DEBUG |client < Frame(fin=True, opcode=1, data=b'{"e":"outboundAccountPosition","E":1615926131286,"u":1615926131285,"B":[{"a":"USDT","f":"1.00000000","l":"0.00000000"}]}', rsv1=False, rsv2=False, rsv3=False)
unicorn_stream                | 2021-03-16 20:22:10,622 - DEBUG |UnicornFy->binance_websocket({"e":"balanceUpdate","E":1615926131286,"a":"USDT","d":"1.00000000","T":1615926131285})
unicorn_stream                | 2021-03-16 20:22:10,627 - ERROR |BinanceWebSocketApiSocket.start_socket(d4b1ac8c-f4c3-4f4a-b6a7-e67bb04ad856, ['arr'], ['!userData']) - Exception General Exception - error_msg: 'data'
unicorn_stream                | 2021-03-16 20:22:10,632 - CRITICAL |BinanceWebSocketApiManager.stream_is_crashing(d4b1ac8c-f4c3-4f4a-b6a7-e67bb04ad856)
unicorn_stream                | 2021-03-16 20:22:10,638 - DEBUG |client - state = CLOSING
unicorn_stream                | 2021-03-16 20:22:10,643 - DEBUG |client > Frame(fin=True, opcode=8, data=b'\x03\xe8', rsv1=False, rsv2=False, rsv3=False)
unicorn_stream                | 2021-03-16 20:22:10,721 - INFO |BinanceWebSocketApiManager.kill_stream(d4b1ac8c-f4c3-4f4a-b6a7-e67bb04ad856)
unicorn_stream                | 2021-03-16 20:22:10,726 - INFO |BinanceWebSocketApiManager._restart_stream(d4b1ac8c-f4c3-4f4a-b6a7-e67bb04ad856, ['arr'], ['!userData'])
unicorn_stream                | 2021-03-16 20:22:10,737 - DEBUG |Using selector: EpollSelector
```

## How Has This Been Tested

I've create a unittest for this payload, also I've tested this release using a Docker image python3.8.1, unicorn-binance-websocket-api 0.29

```
import unicorn_binance_websocket_api
import logging
import os
import sys
import time
import requests
import threading

###############
### Logging ###
###############

# https://docs.python.org/3/library/logging.html#logging-levels
logging.basicConfig(level=logging.DEBUG,
                    filename=os.path.basename(__file__) + '.log',
                    format="{asctime} [{levelname:8}] {process} {thread} {module}: {message}",
                    style="{")


############
### Main ###
############

binance_api_key = os.environ.get('BAPI_KEY')
binance_api_secret = os.environ.get('BSECRET_KEY')

def print_stream_data_from_stream_buffer(binance_websocket_api_manager):
    while True:
        if binance_websocket_api_manager.is_manager_stopping():
            exit(0)
        oldest_stream_data_from_stream_buffer = binance_websocket_api_manager.pop_stream_data_from_stream_buffer()
        if oldest_stream_data_from_stream_buffer is False:
            time.sleep(0.1)
        else:
            print(oldest_stream_data_from_stream_buffer)

def main():
    ubwa_com_spot = unicorn_binance_websocket_api.BinanceWebSocketApiManager(throw_exception_if_unrepairable=True)
    ubwa_com_cross = unicorn_binance_websocket_api.BinanceWebSocketApiManager(exchange="binance.com-margin", throw_exception_if_unrepairable=True)
    ubwa_com_im = unicorn_binance_websocket_api.BinanceWebSocketApiManager(exchange="binance.com-isolated_margin", throw_exception_if_unrepairable=True)

    ubwa_com_spot.create_stream(
        "arr",
        "!userData",
        output="UnicornFy",
        api_key=binance_api_key,
        api_secret=binance_api_secret,
        stream_label="spot"
    )

    ubwa_com_cross.create_stream(
        "arr",
        "!userData",
        api_key=binance_api_key,
        api_secret=binance_api_secret,
        output="UnicornFy",
        stream_label="margin"
    )
    
    ubwa_com_im.create_stream(
        "arr",
        "!userData",
        symbols="BTCUSDT",
        output="UnicornFy",
        api_key=binance_api_key,
        api_secret=binance_api_secret,
        stream_label="BTCUSDT"
    )

    # start a worker process to process to move the received stream_data from the stream_buffer to a print function
    worker_thread_spot = threading.Thread(target=print_stream_data_from_stream_buffer, args=(ubwa_com_spot,))
    worker_thread_spot.start()

    # start a worker process to process to move the received stream_data from the stream_buffer to a print function
    worker_thread_cross = threading.Thread(target=print_stream_data_from_stream_buffer, args=(ubwa_com_cross,))
    worker_thread_cross.start()
    
    # start a worker process to process to move the received stream_data from the stream_buffer to a print function
    worker_thread_im = threading.Thread(target=print_stream_data_from_stream_buffer, args=(ubwa_com_im,))
    worker_thread_im.start()

    # Notifies
    while True:
        ubwa_com_spot.print_summary()
        ubwa_com_cross.print_summary()
        ubwa_com_im.print_summary()
        time.sleep(60)


if __name__ == "__main__":
    main()
```

With this script running just transfer assets between accounts (spot/cross/isolated) and now we get the correct output:

```
protocol: client - event = data_received(<73 bytes>)
protocol: client - event = data_received(<98 bytes>)
protocol: client < Frame(fin=True, opcode=1, data=b'{"e":"balanceUpdate","E":1615938677080,"a":"USDT","d":"1.00000000","T":1615938677079}', rsv1=False, rsv2=False, rsv3=False)
protocol: client < Frame(fin=True, opcode=1, data=b'{"e":"outboundAccountPosition","E":1615938677080,"u":1615938677079,"B":[{"a":"USDT","f":"1.00000000","l":"0.00000000"}]}', rsv1=False, rsv2=False, rsv3=False)
unicorn_fy: UnicornFy->binance_websocket({"e":"balanceUpdate","E":1615938677080,"a":"USDT","d":"1.00000000","T":1615938677079})
unicorn_fy: UnicornFy->binance_com_futures_websocket({'stream_type': '!userData@arr', 'event_type': 'balanceUpdate', 'event_time': 1615938677080, 'asset': 'USDT', 'balance_delta': '1.00000000', 'clear_time': 1615938677079, 'unicorn_fied': ['binance.com-margin', '0.8.0.dev']})
unicorn_binance_websocket_api_manager: BinanceWebSocketApiManager.is_stop_request(9ec4d3a4-3cb8-4cf0-8191-df205705b4d9)
protocol: client - event = data_received(<74 bytes>)
unicorn_binance_websocket_api_manager: BinanceWebSocketApiManager.is_stop_as_crash_request(9ec4d3a4-3cb8-4cf0-8191-df205705b4d9)
protocol: client - event = data_received(<102 bytes>)
unicorn_binance_websocket_api_manager: BinanceWebSocketApiManager.set_heartbeat(9ec4d3a4-3cb8-4cf0-8191-df205705b4d9)
protocol: client < Frame(fin=True, opcode=1, data=b'{"e":"balanceUpdate","E":1615938677080,"a":"USDT","d":"-1.00000000","T":1615938677079}', rsv1=False, rsv2=False, rsv3=False)
unicorn_fy: UnicornFy->binance_websocket({"e":"outboundAccountPosition","E":1615938677080,"u":1615938677079,"B":[{"a":"USDT","f":"1.00000000","l":"0.00000000"}]})
protocol: client < Frame(fin=True, opcode=1, data=b'{"e":"outboundAccountPosition","E":1615938677080,"u":1615938677079,"B":[{"a":"USDT","f":"9.00540157","l":"0.00000000"}]}', rsv1=False, rsv2=False, rsv3=False)
unicorn_fy: UnicornFy->binance_com_futures_websocket({'stream_type': '!userData@arr', 'event_type': 'outboundAccountPosition', 'event_time': 1615938677080, 'last_update_time': 1615938677079, 'balances': [{'asset': 'USDT', 'free': '1.00000000', 'locked': '0.00000000'}], 'unicorn_fied': ['binance.com-margin', '0.8.0.dev']})
unicorn_fy: UnicornFy->binance_websocket({"e":"balanceUpdate","E":1615938677080,"a":"USDT","d":"-1.00000000","T":1615938677079})
unicorn_binance_websocket_api_manager: BinanceWebSocketApiManager.is_stop_request(9ec4d3a4-3cb8-4cf0-8191-df205705b4d9)
unicorn_fy: UnicornFy->binance_com_futures_websocket({'stream_type': '!userData@arr', 'event_type': 'balanceUpdate', 'event_time': 1615938677080, 'asset': 'USDT', 'balance_delta': '-1.00000000', 'clear_time': 1615938677079, 'unicorn_fied': ['binance.com', '0.8.0.dev']})
unicorn_binance_websocket_api_manager: BinanceWebSocketApiManager.is_stop_as_crash_request(9ec4d3a4-3cb8-4cf0-8191-df205705b4d9)
unicorn_binance_websocket_api_manager: BinanceWebSocketApiManager.is_stop_request(98c0c886-4e59-4e79-9635-09da1cb794c9)
unicorn_binance_websocket_api_manager: BinanceWebSocketApiManager.set_heartbeat(9ec4d3a4-3cb8-4cf0-8191-df205705b4d9)
unicorn_binance_websocket_api_manager: BinanceWebSocketApiManager.is_stop_as_crash_request(98c0c886-4e59-4e79-9635-09da1cb794c9)
unicorn_binance_websocket_api_manager: BinanceWebSocketApiManager.set_heartbeat(98c0c886-4e59-4e79-9635-09da1cb794c9)
unicorn_fy: UnicornFy->binance_websocket({"e":"outboundAccountPosition","E":1615938677080,"u":1615938677079,"B":[{"a":"USDT","f":"9.00540157","l":"0.00000000"}]})
unicorn_fy: UnicornFy->binance_com_futures_websocket({'stream_type': '!userData@arr', 'event_type': 'outboundAccountPosition', 'event_time': 1615938677080, 'last_update_time': 1615938677079, 'balances': [{'asset': 'USDT', 'free': '9.00540157', 'locked': '0.00000000'}], 'unicorn_fied': ['binance.com', '0.8.0.dev']})
unicorn_binance_websocket_api_manager: BinanceWebSocketApiManager.is_stop_request(98c0c886-4e59-4e79-9635-09da1cb794c9)
unicorn_binance_websocket_api_manager: BinanceWebSocketApiManager.is_stop_as_crash_request(98c0c886-4e59-4e79-9635-09da1cb794c9)
unicorn_binance_websocket_api_manager: BinanceWebSocketApiManager.set_heartbeat(98c0c886-4e59-4e79-9635-09da1cb794c9)
```


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the 
**[CONTRIBUTING](https://github.com/oliver-zehentleitner/unicorn-fy/blob/master/CONTRIBUTING.md)** 
document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
