### PR TITLE
fix(ktw): Status: unknown -> open on open-questions entries

### DIFF
--- a/context/open-questions.md
+++ b/context/open-questions.md
@@ -3,7 +3,8 @@
 ## Bare `except KeyError: pass` blocks vs. the suite's fail-loud convention
 
 **Type:** undefined — open question awaiting maintainer input, not yet classifiable as decision/workaround/incident/constraint
-**Status:** unknown — needs maintainer input
+**Status:** open — needs maintainer input
+**Evidence:** unknown
 
 `unicorn_fy.py` has dozens of bare `except KeyError: pass` blocks (e.g. around lines 214, 224, 252, 259, 273...) that silently tolerate schema mismatches rather than raising. Commit `31d7fa1` (see `adapters.md`) shows this is a deliberate pattern for tolerating varying/unknown event shapes from Binance, not an oversight.
 


### PR DESCRIPTION
Fixes `Status: unknown` on the open-questions entries — `unknown` is an Evidence level, not a valid Status value; `open` is the correct one for a genuinely unresolved question. Added the previously-missing separate `**Evidence:** unknown` line while at it, since it had been folded into the (wrong) Status text instead of its own field.

Follow-up to the keep-the-why context-schema 0.8.0 rollout, found while backfilling Type. Root-caused and documented upstream: oliver-zehentleitner/keep-the-why#157.