### PR TITLE
Keep the Why: migrate to 0.11.0 and add ktw-lint CI

### DIFF
--- a/.github/workflows/ktw-lint.yml
+++ b/.github/workflows/ktw-lint.yml
@@ -1,0 +1,17 @@
+name: ktw-lint
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  ktw-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oliver-zehentleitner/keep-the-why@lint-latest   # or @lint-v<version> to pin the action
+        with:
+          path: "."
+          strict: "false"    # "true" turns warnings (e.g. missing Type on old entries) into failures
+          # version: "0.11.0.0"   # optional: pin the linter itself; @lint-v<version> above pins only the wrapper

--- a/.keep-the-why
+++ b/.keep-the-why
@@ -1,0 +1,12 @@
+This is machine-readable project state for the Keep the Why skill
+(https://keepthewhy.com). See context/index.md, or this project's own
+README, for what Keep the Why actually is.
+
+<!-- keep-the-why:config -->
+- id: oliver-zehentleitner---unicorn-fy
+- context: `context/`
+- init: complete
+- context-schema: 0.11.0
+- capture-confirmation: confirm-when-unsure
+- source-reference: never
+<!-- /keep-the-why:config -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,9 +149,5 @@ UnicornFy is used automatically by `unicorn-binance-websocket-api` when:
 - `output_default="UnicornFy"` is set on `BinanceWebSocketApiManager()`
 - `output="UnicornFy"` is set on individual `create_stream()` calls
 
-<!-- keep-the-why:config -->
-- context: `context/`
-- init: complete
-- context-schema: 0.9.0
-- capture-confirmation: confirm-when-unsure
-<!-- /keep-the-why:config -->
+Keep the Why's config for this project migrated to .keep-the-why on
+2026-09-04 — requires skill version 0.10.0 or later to read it.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![codecov](https://codecov.io/gh/oliver-zehentleitner/unicorn-fy/branch/master/graph/badge.svg?token=5I03AZ3F5S)](https://codecov.io/gh/oliver-zehentleitner/unicorn-fy)
 [![CodeQL](https://github.com/oliver-zehentleitner/unicorn-fy/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-fy/actions/workflows/codeql-analysis.yml)
 [![Unit Tests](https://github.com/oliver-zehentleitner/unicorn-fy/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-fy/actions/workflows/unit-tests.yml)
+[![ktw-lint](https://github.com/oliver-zehentleitner/unicorn-fy/actions/workflows/ktw-lint.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-fy/actions/workflows/ktw-lint.yml)
 [![Build and Publish GH+PyPi](https://github.com/oliver-zehentleitner/unicorn-fy/actions/workflows/build_wheels.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-fy/actions/workflows/build_wheels.yml)
 [![Conda-Forge Build](https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/unicorn-fy-feedstock?branchName=main)](https://github.com/conda-forge/unicorn-fy-feedstock)
 [![Read the Docs](https://img.shields.io/badge/read-%20docs-yellow)](https://oliver-zehentleitner.github.io/unicorn-fy)

--- a/context/AGENTS.md
+++ b/context/AGENTS.md
@@ -1,0 +1,1 @@
+Before creating or editing anything in this directory, invoke the keep-the-why skill. Don't write to the schema by hand.

--- a/context/CLAUDE.md
+++ b/context/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/context/history.md
+++ b/context/history.md
@@ -2,8 +2,10 @@
 
 ## Three-org lineage
 
+> Superseded — repo now lives under `oliver-zehentleitner`, MIT-licensed.
+
 **Type:** decision
-**Status:** superseded — repo now lives under `oliver-zehentleitner`, MIT-licensed
+**Status:** superseded
 **Evidence:** confirmed
 **Source:** git history
 

--- a/context/open-questions.md
+++ b/context/open-questions.md
@@ -3,7 +3,7 @@
 ## Bare `except KeyError: pass` blocks vs. the suite's fail-loud convention
 
 **Type:** undefined — open question awaiting maintainer input, not yet classifiable as decision/workaround/incident/constraint
-**Status:** open — needs maintainer input
+**Status:** open
 **Evidence:** unknown
 
 `unicorn_fy.py` has dozens of bare `except KeyError: pass` blocks (e.g. around lines 214, 224, 252, 259, 273...) that silently tolerate schema mismatches rather than raising. Commit `31d7fa1` (see `adapters.md`) shows this is a deliberate pattern for tolerating varying/unknown event shapes from Binance, not an oversight.


### PR DESCRIPTION
Suite-wide Keep the Why migration to schema **0.11.0**, plus the structural linter in CI.

**Migrations applied (per `references/migrations.md`)**

- **0.10.0 – dedicated config file:** the `<!-- keep-the-why:config -->` block moves from `AGENTS.md` into `.keep-the-why`. Every existing field is carried over verbatim; new `id` field (`oliver-zehentleitner---<repo>`, derived from the canonical upstream remote, not the fork), and `source-reference` backfilled to its documented default `never`. `AGENTS.md` keeps only the one-line migration note the migration guide asks for.
- **0.10.0 – guard files:** `context/AGENTS.md` + `context/CLAUDE.md`. Where `.gitignore` had an unanchored `CLAUDE.md` pattern it is now `/CLAUDE.md`, so the root file stays local and the nested guard file is tracked.
- **0.10.0 – `context/index.md` sorted alphabetically** (where it wasn't already).
- **0.11.0 – rule renumbering:** checked, no living document in this repo cites a remapped rule number.
- **0.11.0 – CI linting:** `.github/workflows/ktw-lint.yml`, the wizard snippet with `branches: [ master ]` to match the other workflows here. Non-strict by default; `@lint-latest` follows linter publishes.

**Linter-driven cleanups in `context/`**

`ktw-lint --strict` flagged header values outside the documented set. Normalized without dropping information: a trailing reason on `**Status:** superseded — …` moves into a `> Superseded — …` note directly under the entry heading (the same pattern keep-the-why's own `context/` uses); redundant suffixes on `open`/`active` entries (already stated in the entry body, Type reason or Source line) are dropped. See the diff for the exact lines.

**Verification**

- `ktw-lint . --strict` (0.11.0.0): 0 errors, 0 warnings, context-schema 0.11.0.
- Not done here: nothing personal (`AGENTS.local.md` is untracked, `~/.keep-the-why/<id>.md` is per developer), no `personal-defaults` block (optional, project's call).

**Follow-up commit:** `ktw-lint` workflow badge added to `README.md`, directly after the Unit Tests badge.
