### PR TITLE
Keep the Why: bump context-schema to 0.14.0

### DIFF
--- a/.keep-the-why
+++ b/.keep-the-why
@@ -6,7 +6,7 @@ README, for what Keep the Why actually is.
 - id: oliver-zehentleitner---unicorn-fy
 - context: `context/`
 - init: complete
-- context-schema: 0.13.2
+- context-schema: 0.14.0
 - capture-confirmation: confirm-when-unsure
 - source-reference: never
 <!-- /keep-the-why:config -->


### PR DESCRIPTION
Skill release 0.14.0 adds the personal `local-lint` setting only; the migration entry is informational, no entry-format or structural change applies to this repository.

- `.keep-the-why`: `context-schema: 0.13.2` -> `0.14.0`
- `ktw-lint 0.14.0.0 --strict`: 0 errors / 0 warnings before and after
- CI snippet and `context/README.md` template unchanged between 0.13.2 and 0.14.0, nothing else to touch